### PR TITLE
Validate MatchPrincipal strings have SPIFFE prefix

### DIFF
--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -114,6 +114,13 @@ acls:
 `,
 			ExpectedError: errors.New(`config validation failed: duplicate provider "google" for principal "spiffe://foo/bar/baz" (seen 2 times)`),
 		},
+		"invalid config with non-SPIFFE principal ID": {
+			InputFile: `---
+acls:
+- match_principal: "https://foo/bar/baz"
+`,
+			ExpectedError: errors.New(`config validation failed: "https://foo/bar/baz" is not a valid principal matcher`),
+		},
 	}
 
 	for testName, tc := range testCases {


### PR DESCRIPTION
Clearly we want better validation, but thought this made some sense
since we also want to permit globs and so need more than basic URI
validation.

Signed-off-by: Charlie Egan <charlieegan3@users.noreply.github.com>