### PR TITLE
Implement basic principal ACL matching with suffix globs

### DIFF
--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -111,14 +111,21 @@ acls:
   - provider: "google"
     object_reference: "service-account@example.com"
 `,
-			ExpectedError: errors.New(`config validation failed: duplicate provider "google" for principal "spiffe://foo/bar/baz" (seen 2 times)`),
+			ExpectedError: errors.New("config validation failed: principal \"spiffe://foo/bar/baz\" is invalid: duplicate provider \"google\" (seen 2 times)"),
+		},
+		"invalid config with bad ACL match_principals": {
+			InputFile: `---
+acls:
+- match_principal: "missing/spiffe/prefix"
+`,
+			ExpectedError: errors.New("config validation failed: principal \"missing/spiffe/prefix\" is invalid: must start with \"spiffe://\""),
 		},
 		"invalid config with non-SPIFFE principal ID": {
 			InputFile: `---
 acls:
 - match_principal: "https://foo/bar/baz"
 `,
-			ExpectedError: errors.New(`config validation failed: "https://foo/bar/baz" is not a valid principal matcher`),
+			ExpectedError: errors.New("config validation failed: principal \"https://foo/bar/baz\" is invalid: must start with \"spiffe://\""),
 		},
 	}
 

--- a/types/types.go
+++ b/types/types.go
@@ -3,6 +3,7 @@ package types
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 )
 
@@ -10,6 +11,55 @@ import (
 type ACL struct {
 	MatchPrincipal string       `yaml:"match_principal"`
 	Credentials    []Credential `yaml:"credentials"`
+}
+
+func (a *ACL) Validate() []error {
+	var errors []error
+
+	nonWildCardMatchPrincipal := strings.TrimSuffix(a.MatchPrincipal, "/*")
+
+	if strings.Contains(nonWildCardMatchPrincipal, "*") {
+		errors = append(errors, fmt.Errorf(`cannot non-suffix wildcard character "*"`))
+	}
+
+	if !strings.HasPrefix(a.MatchPrincipal, "spiffe://") {
+		errors = append(errors, fmt.Errorf(`must start with "spiffe://"`))
+	} else {
+		if strings.Contains(strings.TrimPrefix(a.MatchPrincipal, "spiffe://"), "//") {
+			errors = append(errors, fmt.Errorf(`cannot have double "//"`))
+		}
+	}
+
+	if strings.HasSuffix(a.MatchPrincipal, "/") {
+		errors = append(errors, fmt.Errorf(`cannot have trailing "/"`))
+	}
+
+	parsedURL, err := url.Parse(nonWildCardMatchPrincipal)
+	if err != nil {
+		errors = append(errors, err)
+	}
+	if parsedURL.String() != nonWildCardMatchPrincipal {
+		errors = append(errors, fmt.Errorf("parsed URI did not match: %q", parsedURL.String()))
+	}
+	if parsedURL.RawQuery != "" {
+		errors = append(errors, fmt.Errorf("URI must have blank query, has: %q", parsedURL.RawQuery))
+	}
+
+	seenProviders := make(map[string]int)
+	for _, provider := range a.Credentials {
+		if _, found := seenProviders[provider.Provider]; !found {
+			seenProviders[provider.Provider] = 1
+		} else {
+			seenProviders[provider.Provider]++
+		}
+	}
+	for provider, count := range seenProviders {
+		if count > 1 {
+			errors = append(errors, fmt.Errorf("duplicate provider %q (seen %d times)", provider, count))
+		}
+	}
+
+	return errors
 }
 
 // Credential represents any remote credential that the connector can give out.
@@ -26,13 +76,6 @@ type Config struct {
 func (c *Config) Validate() []error {
 	var errors []error
 
-	// Validate that MatchPrincipals are SPIFFE IDs or patterns
-	for _, acl := range c.ACLs {
-		if !strings.HasPrefix(acl.MatchPrincipal, "spiffe://") {
-			errors = append(errors, fmt.Errorf("%q is not a valid principal matcher", acl.MatchPrincipal))
-		}
-	}
-
 	// Validate principals are not duplicated
 	seenPrincipals := make(map[string]int)
 	for _, acl := range c.ACLs {
@@ -42,18 +85,10 @@ func (c *Config) Validate() []error {
 			seenPrincipals[acl.MatchPrincipal]++
 		}
 
-		// Validate providers are not duplicated
-		seenProviders := make(map[string]int)
-		for _, provider := range acl.Credentials {
-			if _, found := seenProviders[provider.Provider]; !found {
-				seenProviders[provider.Provider] = 1
-			} else {
-				seenProviders[provider.Provider]++
-			}
-		}
-		for provider, count := range seenProviders {
-			if count > 1 {
-				errors = append(errors, fmt.Errorf("duplicate provider %q for principal %q (seen %d times)", provider, acl.MatchPrincipal, count))
+		// Validate all ACLs
+		if errs := acl.Validate(); len(errs) > 0 {
+			for _, e := range errs {
+				errors = append(errors, fmt.Errorf("principal %q is invalid: %w", acl.MatchPrincipal, e))
 			}
 		}
 	}

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -1,0 +1,87 @@
+package types
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestACLValidate(t *testing.T) {
+	testCases := map[string]struct {
+		ACL            ACL
+		ExpectedErrors []error
+	}{
+		"with valid match principal": {
+			ACL: ACL{
+				MatchPrincipal: "spiffe://bar/foo",
+			},
+			ExpectedErrors: []error{},
+		},
+		"with match principal with non-trailing wildcard": {
+			ACL: ACL{
+				MatchPrincipal: "spiffe://bar/*/foo",
+			},
+			ExpectedErrors: []error{
+				errors.New("cannot non-suffix wildcard character \"*\""),
+			},
+		},
+		"with match principal with wildcard": {
+			ACL: ACL{
+				MatchPrincipal: "spiffe://bar/foo/*",
+			},
+			ExpectedErrors: []error{},
+		},
+		"with match principal with trailing /": {
+			ACL: ACL{
+				MatchPrincipal: "spiffe://bar/foo/",
+			},
+			ExpectedErrors: []error{
+				errors.New("cannot have trailing \"/\""),
+			},
+		},
+		"with match principal with no SPIFFE scheme": {
+			ACL: ACL{
+				MatchPrincipal: "bar/foo",
+			},
+			ExpectedErrors: []error{
+				errors.New("must start with \"spiffe://\""),
+			},
+		},
+		"with match principal invalid URL chars": {
+			ACL: ACL{
+				MatchPrincipal: "spiffe://🌐/foo",
+			},
+			ExpectedErrors: []error{
+				errors.New("parsed URI did not match: \"spiffe://%F0%9F%8C%90/foo\""),
+			},
+		},
+		"with match principal with query": {
+			ACL: ACL{
+				MatchPrincipal: "spiffe://bar/foo?=baz",
+			},
+			ExpectedErrors: []error{
+				errors.New("URI must have blank query, has: \"=baz\""),
+			},
+		},
+		"with duplicated providers": {
+			ACL: ACL{
+				MatchPrincipal: "spiffe://bar/things",
+				Credentials: []Credential{
+					{Provider: "google", ObjectReference: "foo/bar"},
+					{Provider: "google", ObjectReference: "foo/baz"},
+				},
+			},
+			ExpectedErrors: []error{
+				errors.New("duplicate provider \"google\" (seen 2 times)"),
+			},
+		},
+	}
+
+	for testName, tc := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			errs := tc.ACL.Validate()
+			assert.ElementsMatch(t, errs, tc.ExpectedErrors)
+		})
+	}
+}


### PR DESCRIPTION
This implementation might not be the most clear, but it seems to work.

This will allow us to match ACLs for a supplied principal.

Signed-off-by: Charlie Egan <charlieegan3@users.noreply.github.com>