### PR TITLE
Small fixes in sidecar

### DIFF
--- a/internal/pkg/sidecar/sidecar.go
+++ b/internal/pkg/sidecar/sidecar.go
@@ -133,6 +133,9 @@ func (c *CredentialManager) scheduleNext() {
 		if cred == nil {
 			continue
 		}
+		if cred.NotAfter == nil {
+			continue
+		}
 		if cred.NotAfter.AsTime().Before(next) {
 			next = cred.NotAfter.AsTime()
 		}


### PR DESCRIPTION
I noticed we could get a credential starting with ~/ while reviewing #14 .

The refresh channel wasn't initialised.

Credentials may not expire